### PR TITLE
Rename added_label to added_issue_label

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ After an item has been added to a project board (manually or by the previous rul
 - `demilestoned_issue`: When an Issue is removed from a Milestone
 - `closed_issue`: When an Issue is closed
 - `reopened_issue`: When an Issue is reopened
+- `added_issue_label`: When a Label is added to an Issue (requires exactly one argument, the string representing the name of the label)
+- `removed_issue_label`: When a Label is removed from an Issue (requires exactly one argument, the string representing the name of the label)
+
 
 ### Pull Requests
 - `assigned_pullrequest`: When a Pull Request is assigned to a user (but was not before)
@@ -88,10 +91,13 @@ After an item has been added to a project board (manually or by the previous rul
 - `merged_pullrequest`: When a Pull Request is merged
 - `closed_pullrequest`: When a Pull Request is closed
 - `reopened_pullrequest`: When a Pull Request is reopened
+- `added_pullrequest_label`: When a Label is added to a Pull Request (requires exactly one argument, the string representing the name of the label)
+- `removed_pullrequest_label`: When a Label is removed from a Pull Request (requires exactly one argument, the string representing the name of the label)
+
 
 ### Labels
-- `added_label`: (requires exactly one argument, the string representing the name of the label)
-- `removed_label`: (requires exactly one argument, the string representing the name of the label)
+- **deprecated** `added_label`: (requires exactly one argument, the string representing the name of the label)
+- **deprecated** `removed_label`: (requires exactly one argument, the string representing the name of the label)
 
 ### Other
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,10 @@
 function ALWAYS_TRUE () { return true }
 
+async function labelMatcher (logger, context, ruleArgs) {
+  // labels may be defined by a label or an id (for more persistence)
+  return context.payload.label.name === ruleArgs[0] || context.payload.label.id === ruleArgs[0]
+}
+
 module.exports = [
   { ruleName: 'edited_issue', webhookName: 'issues.edited', ruleMatcher: ALWAYS_TRUE },
   { ruleName: 'demilestoned_issue', webhookName: 'issues.demilestoned', ruleMatcher: ALWAYS_TRUE },
@@ -93,19 +98,36 @@ module.exports = [
     }
   },
   {
+    // deprecated
     ruleName: 'added_label',
     webhookName: 'issues.labeled',
-    ruleMatcher: async function (logger, context, ruleArgs) {
-      // labels may be defined by a label or an id (for more persistence)
-      return context.payload.label.name === ruleArgs[0] || context.payload.label.id === ruleArgs[0]
-    }
+    ruleMatcher: labelMatcher
   },
   {
+    // deprecated
     ruleName: 'removed_label',
     webhookName: 'issues.unlabeled',
-    ruleMatcher: async function (logger, context, ruleArgs) {
-      return context.payload.label.name === ruleArgs[0] || context.payload.label.id === ruleArgs[0]
-    }
+    ruleMatcher: labelMatcher
+  },
+  {
+    ruleName: 'added_issue_label',
+    webhookName: 'issues.labeled',
+    ruleMatcher: labelMatcher
+  },
+  {
+    ruleName: 'removed_issue_label',
+    webhookName: 'issues.unlabeled',
+    ruleMatcher: labelMatcher
+  },
+  {
+    ruleName: 'added_pullrequest_label',
+    webhookName: 'pull_request.labeled',
+    ruleMatcher: labelMatcher
+  },
+  {
+    ruleName: 'removed_pullrequest_label',
+    webhookName: 'pull_request.unlabeled',
+    ruleMatcher: labelMatcher
   },
   {
     ruleName: 'accepted_pullrequest',


### PR DESCRIPTION
and add an added_pullrequest_label since those are different webhook events

Kept the existing `added_label` and `removed_label` as deprecated, for backward compatibility.

Fixes #3 